### PR TITLE
Add missing analytics modules

### DIFF
--- a/yosai_intel_dashboard/components/analytics/__init__.py
+++ b/yosai_intel_dashboard/components/analytics/__init__.py
@@ -1,1 +1,12 @@
+"""Exports for the analytics component package."""
+
 from .file_uploader import upload_card, parse_contents
+from .data_preview import data_preview
+from .analytics_charts import analytics_charts
+
+__all__ = [
+    "upload_card",
+    "parse_contents",
+    "data_preview",
+    "analytics_charts",
+]

--- a/yosai_intel_dashboard/components/analytics/analytics_charts.py
+++ b/yosai_intel_dashboard/components/analytics/analytics_charts.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from dash import html
+
+
+def analytics_charts() -> html.Div:
+    """Return a placeholder Div for analytics charts."""
+    return html.Div("Analytics Charts Placeholder")

--- a/yosai_intel_dashboard/components/analytics/data_preview.py
+++ b/yosai_intel_dashboard/components/analytics/data_preview.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Sequence, Dict, Any
+
+from dash import html
+declare = html.Div # for type hints
+# We'll implement simple DataTable using dash_table
+from dash_table import DataTable
+
+
+def data_preview(data: Sequence[Dict[str, Any]]) -> html.Div:
+    """Return a basic DataTable preview wrapped in a Div."""
+    records = list(data)
+    columns = [{"name": key, "id": key} for key in records[0].keys()] if records else []
+    table = DataTable(data=records, columns=columns)
+    return html.Div(table)


### PR DESCRIPTION
## Summary
- extend analytics exports
- add `data_preview` module with a helper function for data table generation
- add `analytics_charts` module with placeholder implementation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f1c587eac8320b58a9b86d00abcc9