### PR TITLE
Fix imports with package initialization

### DIFF
--- a/yosai_intel_dashboard/__init__.py
+++ b/yosai_intel_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Yosai Intel Dashboard package."""

--- a/yosai_intel_dashboard/components/__init__.py
+++ b/yosai_intel_dashboard/components/__init__.py
@@ -1,0 +1,18 @@
+"""Component package aggregator for Yosai Intel Dashboard."""
+
+from .map_panel import layout as map_panel_layout, register_callbacks as register_map_callbacks
+from .analytics import (
+    upload_card,
+    parse_contents,
+    data_preview,
+    analytics_charts,
+)
+
+__all__ = [
+    "map_panel_layout",
+    "register_map_callbacks",
+    "upload_card",
+    "parse_contents",
+    "data_preview",
+    "analytics_charts",
+]

--- a/yosai_intel_dashboard/pages/deep_analytics.py
+++ b/yosai_intel_dashboard/pages/deep_analytics.py
@@ -1,0 +1,12 @@
+"""Deep analytics page layout."""
+
+from dash import html
+from ..components.analytics import upload_card, data_preview, analytics_charts
+
+layout = html.Div(
+    [
+        upload_card(),
+        data_preview([]),
+        analytics_charts(),
+    ]
+)


### PR DESCRIPTION
## Summary
- add `__init__.py` files so that `components` is a real package
- re-export analytics helpers in `components`
- add minimal page using analytics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python yosai_intel_dashboard/app.py` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_684f1f9136908320994a6d0cc3a4a94e